### PR TITLE
Set URL action in newly created 2Do Task

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,7 +1,7 @@
 'use strict';
 
-function createTask(chrome, title, note) {
-  let task = 'twodo://x-callback-url/add?task=' + encodeURI(title) + '&note=' + encodeURI(note);
+function createTask(chrome, title, note, url) {
+  let task = 'twodo://x-callback-url/add?task=' + encodeURI(title) + '&note=' + encodeURI(note) + '&action=url:' + encodeURI(url);
   chrome.tabs.update({
    url: task
   });
@@ -14,17 +14,18 @@ chrome.browserAction.onClicked.addListener(function(aTab) {
   }, function(selectedText) {
 
     let title = aTab.title;
-    let note = aTab.url;
+    let url = aTab.url;
+    let note = '';
 
     if (selectedText instanceof Array && selectedText.length > 0) {
       selectedText = selectedText[0];
     }
 
     if (selectedText && selectedText.length) {
-      note = note + "\n--\n" + selectedText;
+      note = selectedText;
     }
 
-    createTask(chrome, title, note);
+    createTask(chrome, title, note, url);
 
   });
 });


### PR DESCRIPTION
Still add any selected text as a note, but use the current tab's URL as the
2Do action instead.